### PR TITLE
FEAT: Crop image of player to square to prevent stretching

### DIFF
--- a/src/main/kotlin/tech/thatgravyboat/craftify/ui/UIPlayer.kt
+++ b/src/main/kotlin/tech/thatgravyboat/craftify/ui/UIPlayer.kt
@@ -18,6 +18,7 @@ import tech.thatgravyboat.craftify.utils.Utils.clearFormatting
 import tech.thatgravyboat.jukebox.api.state.State
 import java.net.URL
 import java.util.concurrent.CompletableFuture
+import kotlin.math.min
 
 class UIPlayer : UIBlock(ConfigColorConstraint("background")) {
 
@@ -111,7 +112,10 @@ class UIPlayer : UIBlock(ConfigColorConstraint("background")) {
                         image.clearChildren()
                         image.addChild(
                             UIImage(CompletableFuture.supplyAsync {
-                                return@supplyAsync SingleImageCache[url] ?: UIImage.get(url).also {
+                                return@supplyAsync SingleImageCache[url] ?: UIImage.get(url).let {
+                                    val scale = min(it.width / 40, it.height / 40);
+                                    it.getSubimage(it.width / 2 - 20 * scale, it.height / 2 - 20 * scale, 40 * scale, 40 * scale);
+                                }.also {
                                     SingleImageCache[url] = it
                                 }
                             }, EmptyImageProvider, EmptyImageProvider).constrain {


### PR DESCRIPTION
When using ytmd the thumbnails of the songs are in 16:9 format which results in them being squished into the square.
Instead this change crops the image to the center region of the image